### PR TITLE
Clean up TypeScript examples

### DIFF
--- a/TypeScript/1-association.ts
+++ b/TypeScript/1-association.ts
@@ -1,16 +1,10 @@
 class Point {
-  public x: number;
-  public y: number;
-
-  constructor(x: number, y: number) {
-    this.x = x;
-    this.y = y;
-  }
+  constructor(public x: number, public y: number) {}
 }
 
 class Line {
-  public a: Point;
-  public b: Point;
+  public a: Point | undefined;
+  public b: Point | undefined;
 
   get length() {
     const { a, b } = this;

--- a/TypeScript/2-aggregation.ts
+++ b/TypeScript/2-aggregation.ts
@@ -1,21 +1,9 @@
 class Point {
-  readonly x: number;
-  readonly y: number;
-
-  constructor(x: number, y: number) {
-    this.x = x;
-    this.y = y;
-  }
+  constructor(readonly x: number, readonly y: number) {}
 }
 
 class Line {
-  readonly a: Point;
-  readonly b: Point;
-
-  constructor(p1: Point, p2: Point) {
-    this.a = p1;
-    this.b = p2;
-  }
+  constructor(readonly a: Point, readonly b: Point) {}
 
   get length() {
     const { a, b } = this;

--- a/TypeScript/3-composition.ts
+++ b/TypeScript/3-composition.ts
@@ -1,11 +1,5 @@
 class Point {
-  readonly x: number;
-  readonly y: number;
-
-  constructor(x: number, y: number) {
-    this.x = x;
-    this.y = y;
-  }
+  constructor(public x: number, public y: number) {}
 }
 
 class Line {


### PR DESCRIPTION
This fixes code in `1-association.ts` in class `Line` which wouldn't compile due to uninitialized properties `a` and `b` and changes classes to use proper property syntax to avoid code duplication.