### PR TITLE
Fix `8-delegation.js` example and typos 

### DIFF
--- a/JavaScript/7-inheritance.js
+++ b/JavaScript/7-inheritance.js
@@ -6,11 +6,11 @@ class Channel extends EventEmitter {
   constructor(name) {
     super();
     this.name = name;
-    this.histry = [];
+    this.history = [];
   }
 
   send(from, message) {
-    this.histry.push({ from, message });
+    this.history.push({ from, message });
     this.emit('message', from, message);
   }
 }

--- a/JavaScript/8-delegation.js
+++ b/JavaScript/8-delegation.js
@@ -6,11 +6,11 @@ class Channel {
   constructor(application, name) {
     this.application = application;
     this.name = name;
-    this.histry = [];
+    this.history = [];
   }
 
   send(from, message) {
-    this.histry.push({ from, message });
+    this.history.push({ from, message });
     this.application.send(this.name, from, message);
   }
 }
@@ -21,8 +21,8 @@ class Application {
     this.channels = {};
   }
 
-  send(channel, from, message) {
-    this.events.emit('message', this.name, from, message);
+  send(channelName, from, message) {
+    this.events.emit('message', channelName, from, message);
   }
 
   createChannel(name) {
@@ -41,8 +41,8 @@ chat.events.on('channel', (name) => {
   console.log(`Channel ${name} created`);
 });
 
-chat.events.on('message', (channel, from, message) => {
-  console.log(`${from}@${channel}> ${message}`);
+chat.events.on('message', (channelName, from, message) => {
+  console.log(`${from}@${channelName}> ${message}`);
 });
 
 const channel = chat.createChannel('HowProgrammingWorks');


### PR DESCRIPTION
`8-delegation.js` example was broken.

Before: 
<img width="287" alt="image" src="https://github.com/user-attachments/assets/8bf00cb8-0bbf-4a91-a2d0-2a2de1a047e7">

After: 
<img width="352" alt="image" src="https://github.com/user-attachments/assets/7c84e048-0b73-493d-9845-e3527dbc5975">

